### PR TITLE
Fix system names (slash instead of dot)

### DIFF
--- a/iolib.termios.asd
+++ b/iolib.termios.asd
@@ -14,7 +14,7 @@
   :description "Termios (3p) api wrappers"
   :maintainer "Razbegaev N.V. <marsijanin@gmail.com>"
   :licence "MIT"
-  :depends-on (:iolib.base :iolib.syscalls :iolib.streams :cffi :cffi-grovel :trivial-garbage)
+  :depends-on (:iolib/base :iolib/syscalls :iolib/streams :cffi :cffi-grovel :trivial-garbage)
   :components
   #+unix
   (#+ecl


### PR DESCRIPTION
The latest commit (0fef8c1) of IOLIB (https://github.com/sionescu/iolib) uses slashes instead of dots in system names.

Changing this fixes the compilation process of IOLIB.TERMIO.

Tested on SBCL.
